### PR TITLE
Fix host_system_name for linux

### DIFF
--- a/toolchain/arm-none-eabi/linux_aarch64/BUILD
+++ b/toolchain/arm-none-eabi/linux_aarch64/BUILD
@@ -65,7 +65,7 @@ cc_arm_none_eabi_config(
     name = "config",
     gcc_repo = compiler,
     gcc_version = "9.2.1",
-    host_system_name = "x86-darwin",
+    host_system_name = "linux_aarch64",
     toolchain_identifier = "arm_none_eabi_linux_x86_64",
     wrapper_path = "arm-none-eabi/linux_aarch64",
 )

--- a/toolchain/arm-none-eabi/linux_aarch64/BUILD
+++ b/toolchain/arm-none-eabi/linux_aarch64/BUILD
@@ -66,6 +66,6 @@ cc_arm_none_eabi_config(
     gcc_repo = compiler,
     gcc_version = "9.2.1",
     host_system_name = "linux_aarch64",
-    toolchain_identifier = "arm_none_eabi_linux_x86_64",
+    toolchain_identifier = "arm_none_eabi_linux_aarch64",
     wrapper_path = "arm-none-eabi/linux_aarch64",
 )

--- a/toolchain/arm-none-eabi/linux_x86_64/BUILD
+++ b/toolchain/arm-none-eabi/linux_x86_64/BUILD
@@ -65,7 +65,7 @@ cc_arm_none_eabi_config(
     name = "config",
     gcc_repo = compiler,
     gcc_version = "9.2.1",
-    host_system_name = "x86-darwin",
+    host_system_name = "linux_x86_64",
     toolchain_identifier = "arm_none_eabi_linux_x86_64",
     wrapper_path = "arm-none-eabi/linux_x86_64",
 )


### PR DESCRIPTION
This looks like some copy-paste leftover but I'm not sure how bazel uses this info.